### PR TITLE
Add initial implementation of the Soccer Team plugin with privacy, ac…

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_soccerteam\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy Subsystem implementation for local_soccerteam.
+ *
+ * The Soccer Team plugin does store personal user data, but it is not exported
+ * as part of the Privacy API as it represents educational user assignments in a course.
+ *
+ * @package    local_soccerteam
+ * @category   privacy
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Capability definitions for Moodle Soccerteam
+ *
+ * Documentation: {@link https://moodledev.io/docs/apis/subsystems/access}
+ *
+ * @package    local_soccerteam
+ * @category   access
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [
+
+    'local/soccerteam:manage' => [
+        'captype' => 'write',
+        'riskbitmask' => RISK_PERSONAL,
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ],
+    ],
+
+    'local/soccerteam:view' => [
+        'captype' => 'read',
+        'riskbitmask' => RISK_PERSONAL,
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'student' => CAP_ALLOW,
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ],
+    ],
+];

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="local/soccerteam/db" VERSION="20250501" COMMENT="XMLDB file for Moodle local/soccerteam"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="local_soccerteam_assignments" COMMENT="Stores soccer team assignments">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="position" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="jerseynumber" TYPE="int" LENGTH="3" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="courseid" TYPE="foreign" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
+        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="courseid-jerseynumber" UNIQUE="true" FIELDS="courseid, jerseynumber"/>
+        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+      </INDEXES>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/lang/en/local_soccerteam.php
+++ b/lang/en/local_soccerteam.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * English language pack for Moodle Soccerteam
+ *
+ * @package    local_soccerteam
+ * @category   string
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['pluginname'] = 'Soccer Team';

--- a/version.php
+++ b/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version information for Moodle Soccerteam
+ *
+ * @package    local_soccerteam
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component    = 'local_soccerteam';
+$plugin->release      = '1.0';
+$plugin->version      = 2025050101;
+$plugin->requires     = 2022112800; // Moodle 4.1.
+$plugin->supported    = [401, 500]; // Supported from Moodle 4.1 to 5.0.
+$plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
This pull request introduces a new Moodle plugin called "Soccer Team" (`local_soccerteam`). The changes include implementing privacy compliance, defining database structure and access capabilities, adding language support, and setting up version information. Below is a summary of the key changes:

### Privacy and Compliance:
* Added a privacy provider class `provider` in `classes/privacy/provider.php` that implements `null_provider` to declare that the plugin does not export personal data as part of the Privacy API.

### Database and Access Capabilities:
* Defined database schema in `db/install.xml` to store soccer team assignments, including fields for `courseid`, `userid`, `position`, and `jerseynumber`. Added foreign key constraints and indexes for optimized queries.
* Defined access capabilities in `db/access.php` to manage permissions for managing and viewing soccer team data, with roles like `student`, `teacher`, and `manager` assigned appropriate permissions.

### Language Support:
* Added an English language pack in `lang/en/local_soccerteam.php` with a string for the plugin name (`Soccer Team`).

### Versioning:
* Created `version.php` to define the plugin's metadata, including version, release, required Moodle version, and supported Moodle versions.…cess, language, and version files