### PR TITLE
Add a clearly labelled option Soccer Team to the secondary navigation…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -15,17 +15,32 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * English language pack for Moodle Soccerteam
+ * Library of functions for local_soccerteam
  *
  * @package    local_soccerteam
- * @category   string
  * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+/**
+ * Extends navigation for the soccer team plugin.
+ *
+ * @param global_navigation $navigation The navigation object
+ * @param stdClass $course The course object
+ * @param context_course $context The course context
+ * @return void
+ */
+function local_soccerteam_extend_navigation_course($navigation, $course, $context) {
+    if (has_capability('local/soccerteam:view', $context)) {
+        $url = new moodle_url('/local/soccerteam/index.php', ['id' => $course->id]);
+        $navigation->add(
+            get_string('pluginname', 'local_soccerteam'),
+            $url,
+            navigation_node::TYPE_SETTING,
+            null,
+            'soccerteam',
+            new pix_icon('i/groups', '')
+        );
+    }
+}
 
-$string['pluginname'] = 'Soccer Team';
-$string['privacy:metadata'] = 'The Moodle Soccerteam plugin doesn\'t store any personal data.';
-$string['soccerteam:manage'] = 'Manage Moodle Soccer Team';
-$string['soccerteam:view'] = 'View Moodle Soccer Team';


### PR DESCRIPTION
This pull request introduces a new Moodle plugin called "Soccer Team" with functionality for managing and viewing soccer teams. The key changes include adding language strings for the plugin, defining privacy metadata, and implementing a function to extend course navigation.

### Language and Privacy Updates:
* Added new language strings in `lang/en/local_soccerteam.php` for the plugin name, privacy metadata, and capabilities (`soccerteam:manage` and `soccerteam:view`).

### Functional Enhancements:
* Created a new `lib.php` file containing the `local_soccerteam_extend_navigation_course` function to add a navigation link for the Soccer Team plugin in the course context, based on user capabilities.… menu within a course