### PR TITLE
Add external API functions for retrieving player and Teams data

### DIFF
--- a/classes/external/get_player_details.php
+++ b/classes/external/get_player_details.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_soccerteam\external;
+
+/**
+ * Class get_player_details
+ *
+ * @package    local_soccerteam
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class get_player_details extends \external_api {
+    /**
+     * Returns description of get_player_details parameters.
+     *
+     * @return \external_function_parameters
+     */
+    public static function get_player_detail_parameters() {
+        return new \external_function_parameters(
+            [
+                'courseid' => new \external_value(PARAM_INT, 'Course ID'),
+                'userid' => new \external_value(PARAM_INT, 'User ID'),
+            ]
+        );
+    }
+
+    /**
+     * Returns player details for a specific student in a course.
+     *
+     * @param int $courseid The course ID
+     * @param int $userid The user ID
+     * @return array player details
+     * @throws \moodle_exception
+     */
+    public static function get_player_detail($courseid, $userid) {
+        global $DB;
+
+        // Parameter validation.
+        $params = self::validate_parameters(
+            self::get_player_detail_parameters(),
+            ['courseid' => $courseid, 'userid' => $userid]
+        );
+
+        // Context validation.
+        $context = \context_course::instance($params['courseid']);
+        self::validate_context($context);
+
+        // Capability check.
+        require_capability('local/soccerteam:view', $context);
+
+        // Fetch player data.
+        $playerdata = $DB->get_record(
+            'local_soccerteam_assignments',
+            ['courseid' => $params['courseid'], 'userid' => $params['userid']]
+        );
+
+        if (!$playerdata) {
+            throw new \moodle_exception('playernotfound', 'local_soccerteam');
+        }
+
+        $user = $DB->get_record('user', ['id' => $playerdata->userid], 'id, firstname, lastname, email');
+        if (!$user) {
+            throw new \moodle_exception('usernotfound', 'local_soccerteam');
+        }
+
+        return [
+            'userid' => $playerdata->userid,
+            'fullname' => fullname($user),
+            'email' => $user->email,
+            'position' => $playerdata->position,
+            'jerseynumber' => $playerdata->jerseynumber,
+            'timemodified' => $playerdata->timemodified,
+        ];
+    }
+
+    /**
+     * Returns description of get_player_details returns.
+     *
+     * @return \external_single_structure
+     */
+    public static function get_player_detail_returns() {
+        return new \external_single_structure(
+            [
+                'userid' => new \external_value(PARAM_INT, 'User ID'),
+                'fullname' => new \external_value(PARAM_TEXT, 'User full name'),
+                'email' => new \external_value(PARAM_TEXT, 'User email'),
+                'position' => new \external_value(PARAM_TEXT, 'Player position'),
+                'jerseynumber' => new \external_value(PARAM_INT, 'Jersey number'),
+                'timemodified' => new \external_value(PARAM_INT, 'Last modified timestamp'),
+            ]
+        );
+    }
+}

--- a/classes/external/get_team_bycourse.php
+++ b/classes/external/get_team_bycourse.php
@@ -1,0 +1,103 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_soccerteam\external;
+
+/**
+ * Class get_team_bycourse
+ *
+ * @package    local_soccerteam
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class get_team_bycourse extends \external_api {
+    /**
+     * Returns description of get_team_by_course parameters.
+     *
+     * @return \external_function_parameters
+     */
+    public static function get_team_by_course_parameters() {
+        return new \external_function_parameters(
+            [
+                'courseid' => new \external_value(PARAM_INT, 'Course ID'),
+            ]
+        );
+    }
+
+    /**
+     * Returns the soccer team data for a course.
+     *
+     * @param int $courseid The course ID
+     * @return array of team members
+     * @throws \moodle_exception
+     */
+    public static function get_team_by_course($courseid) {
+        global $DB;
+
+        // Parameter validation.
+        $params = self::validate_parameters(
+            self::get_team_by_course_parameters(),
+            ['courseid' => $courseid]
+        );
+
+        // Context validation.
+        $context = \context_course::instance($params['courseid']);
+        self::validate_context($context);
+
+        // Capability check.
+        require_capability('local/soccerteam:view', $context);
+
+        // Fetch team data.
+        $teamdata = $DB->get_records('local_soccerteam_assignments', ['courseid' => $params['courseid']]);
+
+        $result = [];
+
+        // Prepare data for output.
+        foreach ($teamdata as $member) {
+            $user = $DB->get_record('user', ['id' => $member->userid], 'id, firstname, lastname');
+            if (!$user) {
+                // Skip if user not found.
+                continue;
+            }
+            $result[] = [
+                'userid' => $member->userid,
+                'fullname' => fullname($user),
+                'position' => $member->position,
+                'jerseynumber' => $member->jerseynumber,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns description of get_team_by_course returns.
+     *
+     * @return \external_multiple_structure
+     */
+    public static function get_team_by_course_returns() {
+        return new \external_multiple_structure(
+            new \external_single_structure(
+                [
+                    'userid' => new \external_value(PARAM_INT, 'User ID'),
+                    'fullname' => new \external_value(PARAM_TEXT, 'User full name'),
+                    'position' => new \external_value(PARAM_TEXT, 'Player position'),
+                    'jerseynumber' => new \external_value(PARAM_INT, 'Jersey number'),
+                ]
+            )
+        );
+    }
+}

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * External functions and service declaration for Moodle Soccerteam
+ *
+ * Documentation: {@link https://moodledev.io/docs/apis/subsystems/external/description}
+ *
+ * @package    local_soccerteam
+ * @category   webservice
+ * @copyright  2025 Khairu Aqsara <wenkhairu@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$functions = [
+    'local_soccerteam_get_team_by_course' => [
+        'classname'     => 'local_soccerteam\external\get_team_bycourse',
+        'methodname'    => 'get_team_by_course',
+        'classpath'     => 'local/soccerteam/classes/external/get_team_bycourse.php',
+        'description'   => 'Get soccer team data for a specific course',
+        'type'          => 'read',
+        'capabilities'  => 'local/soccerteam:view',
+    ],
+    'local_soccerteam_get_player_details' => [
+        'classname'     => 'local_soccerteam\external\get_player_details',
+        'methodname'    => 'get_player_detail',
+        'classpath'     => 'local/soccerteam/classes/external/get_player_details.php',
+        'description'   => 'Get details for a specific player in a course',
+        'type'          => 'read',
+        'capabilities'  => 'local/soccerteam:view',
+    ],
+];
+
+// Define the service.
+$services = [
+    'Soccer Team API' => [
+        'functions' => [
+            'local_soccerteam_get_team_by_course',
+            'local_soccerteam_get_player_details',
+        ],
+        'restrictedusers' => 0,
+        'enabled' => 1,
+        'shortname' => 'local_soccerteam_api',
+    ],
+];

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'local_soccerteam';
 $plugin->release      = '1.0';
-$plugin->version      = 2025050101;
+$plugin->version      = 2025050103;
 $plugin->requires     = 2022112800; // Moodle 4.1.
 $plugin->supported    = [401, 500]; // Supported from Moodle 4.1 to 5.0.
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
This pull request introduces new web service functionalities for the `local_soccerteam` plugin in Moodle, enabling retrieval of soccer team and player details associated with courses. It also includes service declarations and a version update.

### New Web Service Functionalities:

* **Player Details Retrieval**:
  - Added the `get_player_details` class in `classes/external/get_player_details.php` to fetch detailed information about a specific player in a course, including their full name, email, position, jersey number, and last modified timestamp.

* **Team Details Retrieval**:
  - Added the `get_team_bycourse` class in `classes/external/get_team_bycourse.php` to retrieve a list of team members for a specific course, including their user ID, full name, position, and jersey number.

### Service Declarations:

* **Service Registration**:
  - Defined external functions `local_soccerteam_get_team_by_course` and `local_soccerteam_get_player_details` in `db/services.php`, specifying their class paths, descriptions, and capabilities. Also registered these functions under the `Soccer Team API` service.

### Plugin Version Update:

* **Version Increment**:
  - Updated the plugin version in `version.php` from `2025050101` to `2025050103` to reflect the new features.…a by course