### PR TITLE
Update version.php and add GitHub workflows for Moodle plugin quality…

### DIFF
--- a/.github/workflows/m41.yml
+++ b/.github/workflows/m41.yml
@@ -1,0 +1,79 @@
+name: Moodle Plugin Quality Check for Moodle 4.1 with php 7.4
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  quality:
+    name: Checking Plugin
+    runs-on: ubuntu-22.04
+
+    services:
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4','8.1']
+        moodle-branch: ['MOODLE_401_STABLE']
+        database: [mariadb]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          IGNORE_PATHS: 'vendor,plugin/vendor'
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --standard=moodle --max-warnings 50
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --testdox
+
+      - name: Mark cancelled jobs as failed.
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,79 @@
+name: Moodle Plugin Quality Check
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  quality:
+    name: Checking Plugin
+    runs-on: ubuntu-22.04
+
+    services:
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1','8.2']
+        moodle-branch: ['MOODLE_402_STABLE','MOODLE_403_STABLE','MOODLE_404_STABLE']
+        database: [mariadb]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          IGNORE_PATHS: 'vendor,plugin/vendor'
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --standard=moodle --max-warnings 50
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --testdox
+
+      - name: Mark cancelled jobs as failed.
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/version.php
+++ b/version.php
@@ -28,5 +28,4 @@ $plugin->component    = 'local_soccerteam';
 $plugin->release      = '1.0';
 $plugin->version      = 2025050103;
 $plugin->requires     = 2022112800; // Moodle 4.1.
-$plugin->supported    = [401, 500]; // Supported from Moodle 4.1 to 5.0.
-$plugin->maturity     = MATURITY_STABLE;
+$plugin->supported    = [401, 404]; // Supported from Moodle 4.1 to 5.4.


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows for Moodle plugin quality checks and updates the plugin's supported Moodle versions. The workflows are designed to streamline testing across different PHP versions and Moodle branches, while the version update adjusts the supported range of Moodle versions.

### Workflow Additions:

* [`.github/workflows/m41.yml`](diffhunk://#diff-904e216042b0bc41b8792d6fb3fb4e8f01f8a946d77d302cf0dd824b4ce6c08cR1-R79): Added a new workflow for Moodle 4.1 testing with PHP 7.4 and 8.1. It includes steps for setting up the environment, running linting, code checks, and PHPUnit tests.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R1-R79): Added a workflow for broader testing with PHP 8.1 and 8.2 across Moodle branches 4.2, 4.3, and 4.4. Similar to the above, it includes environment setup and various quality checks.

### Plugin Version Update:

* [`version.php`](diffhunk://#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726bL31-R31): Updated the supported Moodle versions to range from 4.1 to 4.4, reflecting compatibility adjustments.… checks